### PR TITLE
feat: 매장 리스트 반환 API 개발

### DIFF
--- a/src/main/java/org/sopt/tablingServer/common/exception/model/ErrorType.java
+++ b/src/main/java/org/sopt/tablingServer/common/exception/model/ErrorType.java
@@ -12,12 +12,11 @@ public enum ErrorType {
     /**
      * 404 NOT FOUND
      */
-    NOT_FOUND_MEMBER_ERROR(HttpStatus.NOT_FOUND, "존재하지 않는 멤버입니다"),
 
     /**
      * 500 INTERNAL SERVER ERROR
      */
-    INTERNAL_SERVER_ERROR(HttpStatus.INTERNAL_SERVER_ERROR, "알 수 없는 서버 에러가 발생했습니다"),
+    INTERNAL_SERVER_ERROR(HttpStatus.INTERNAL_SERVER_ERROR, "알 수 없는 서버 에러가 발생했습니다."),
     ;
 
     private final HttpStatus httpStatus;

--- a/src/main/java/org/sopt/tablingServer/common/exception/model/SuccessType.java
+++ b/src/main/java/org/sopt/tablingServer/common/exception/model/SuccessType.java
@@ -13,6 +13,7 @@ public enum SuccessType {
      * 200 OK
      */
     PROCESS_SUCCESS(HttpStatus.OK, "OK"),
+    GET_SHOP_LIST_BY_AVERAGE_WAITING_SUCCESS(HttpStatus.OK, "일 평균 대기인원을 기준으로 서울 남부 인기 매장 리스트 반환이 완료되었습니다.")
 
     /**
      * 201 CREATED

--- a/src/main/java/org/sopt/tablingServer/shop/ShopController.java
+++ b/src/main/java/org/sopt/tablingServer/shop/ShopController.java
@@ -1,0 +1,25 @@
+package org.sopt.tablingServer.shop;
+
+import lombok.RequiredArgsConstructor;
+import org.sopt.tablingServer.common.dto.ApiResponse;
+import org.sopt.tablingServer.shop.dto.response.ShopResponse;
+import org.springframework.web.bind.annotation.GetMapping;
+import org.springframework.web.bind.annotation.RequestMapping;
+import org.springframework.web.bind.annotation.RestController;
+
+import java.util.List;
+
+import static org.sopt.tablingServer.common.exception.model.SuccessType.GET_SHOP_LIST_BY_AVERAGE_WAITING_SUCCESS;
+
+@RestController
+@RequestMapping("/shops")
+@RequiredArgsConstructor
+public class ShopController {
+
+    private final ShopService shopService;
+
+    @GetMapping
+    public ApiResponse<List<ShopResponse>> getShopList() {
+        return ApiResponse.success(GET_SHOP_LIST_BY_AVERAGE_WAITING_SUCCESS, shopService.getShopListByAverageWaiting());
+    }
+}

--- a/src/main/java/org/sopt/tablingServer/shop/ShopService.java
+++ b/src/main/java/org/sopt/tablingServer/shop/ShopService.java
@@ -1,0 +1,26 @@
+package org.sopt.tablingServer.shop;
+
+import lombok.RequiredArgsConstructor;
+import org.sopt.tablingServer.shop.dto.response.ShopResponse;
+import org.sopt.tablingServer.shop.infrastructure.ShopJpaRepository;
+import org.springframework.stereotype.Service;
+import org.springframework.transaction.annotation.Transactional;
+
+import java.util.List;
+import java.util.stream.Collectors;
+
+@Service
+@RequiredArgsConstructor
+@Transactional(readOnly = true)
+public class ShopService {
+
+    private final ShopJpaRepository shopJpaRepository;
+
+
+    public List<ShopResponse> getShopListByAverageWaiting() {
+
+        return shopJpaRepository.findAllByOrderByAverageWaitingDesc().stream()
+                .map(ShopResponse::of)
+                .collect(Collectors.toList());
+    }
+}

--- a/src/main/java/org/sopt/tablingServer/shop/dto/response/ShopResponse.java
+++ b/src/main/java/org/sopt/tablingServer/shop/dto/response/ShopResponse.java
@@ -1,0 +1,31 @@
+package org.sopt.tablingServer.shop.dto.response;
+
+import com.fasterxml.jackson.databind.PropertyNamingStrategies;
+import com.fasterxml.jackson.databind.annotation.JsonNaming;
+import org.sopt.tablingServer.shop.domain.Shop;
+
+@JsonNaming(PropertyNamingStrategies.SnakeCaseStrategy.class)
+public record ShopResponse(
+        String name,
+        float averageStar,
+        int reviewCount,
+        String shopCategory,
+        String shortAddress,
+        int averageWaiting,
+        int currentWaiting,
+        String profilePhotoUrl
+) {
+
+    public static ShopResponse of(Shop shop) {
+        return new ShopResponse(
+                shop.getName(),
+                shop.getAverageStar(),
+                shop.getReviewCount(),
+                shop.getShopCategory().getValue(),
+                shop.getShortAddress(),
+                shop.getAverageWaiting(),
+                shop.getCurrentWaiting(),
+                shop.getProfilePhotoUrl()
+        );
+    }
+}

--- a/src/main/java/org/sopt/tablingServer/shop/dto/response/ShopResponse.java
+++ b/src/main/java/org/sopt/tablingServer/shop/dto/response/ShopResponse.java
@@ -6,6 +6,7 @@ import org.sopt.tablingServer.shop.domain.Shop;
 
 @JsonNaming(PropertyNamingStrategies.SnakeCaseStrategy.class)
 public record ShopResponse(
+        Long shopId,
         String name,
         float averageStar,
         int reviewCount,
@@ -18,6 +19,7 @@ public record ShopResponse(
 
     public static ShopResponse of(Shop shop) {
         return new ShopResponse(
+                shop.getId(),
                 shop.getName(),
                 shop.getAverageStar(),
                 shop.getReviewCount(),

--- a/src/main/java/org/sopt/tablingServer/shop/infrastructure/ShopJpaRepository.java
+++ b/src/main/java/org/sopt/tablingServer/shop/infrastructure/ShopJpaRepository.java
@@ -1,0 +1,10 @@
+package org.sopt.tablingServer.shop.infrastructure;
+
+import org.sopt.tablingServer.shop.domain.Shop;
+import org.springframework.data.jpa.repository.JpaRepository;
+
+import java.util.List;
+
+public interface ShopJpaRepository extends JpaRepository<Shop, Long> {
+    List<Shop> findAllByOrderByAverageWaitingDesc();
+}


### PR DESCRIPTION
## 📌 관련 이슈
closed #1

## ✨ 어떤 이유로 변경된 내용인지
- 일 평균 대기인원을 기준으로 서울 남부 인기 매장 리스트를 반환해주는 API를 개발했습니다.

- JPA Repository의 메서드명을 활용한 쿼리 생성 기능을 적용해보았습니다.
  <img width="450" alt="image" src="https://github.com/DOSOPT-CDS-TABLING/Tabling-Server/assets/67463603/1b1288ad-9c0d-4f44-b27d-6935eed2635a">

## 🙏 검토 혹은 리뷰어에게 남기고 싶은 말
- 포스트맨 테스트 결과입니다

  <img width="800" alt="image" src="https://github.com/DOSOPT-CDS-TABLING/Tabling-Server/assets/67463603/47af84af-f609-4ce6-a801-999e3e2d621e">
