### PR TITLE
feat: 매장 상세 정보 반환 API 개발

### DIFF
--- a/src/main/java/org/sopt/tablingServer/common/exception/model/ErrorType.java
+++ b/src/main/java/org/sopt/tablingServer/common/exception/model/ErrorType.java
@@ -12,6 +12,7 @@ public enum ErrorType {
     /**
      * 404 NOT FOUND
      */
+    NOT_FOUND_SHOP_ERROR(HttpStatus.NOT_FOUND, "일치하는 매장 정보가 없습니다"),
 
     /**
      * 500 INTERNAL SERVER ERROR

--- a/src/main/java/org/sopt/tablingServer/common/exception/model/SuccessType.java
+++ b/src/main/java/org/sopt/tablingServer/common/exception/model/SuccessType.java
@@ -14,7 +14,7 @@ public enum SuccessType {
      */
     PROCESS_SUCCESS(HttpStatus.OK, "OK"),
     GET_SHOP_LIST_BY_AVERAGE_WAITING_SUCCESS(HttpStatus.OK, "일 평균 대기인원을 기준으로 서울 남부 인기 매장 리스트 반환이 완료되었습니다."),
-    GET_SHOP_DETAIL_SUCCESS(HttpStatus.OK, "매장 상세 정보 반완이 완료되었습니다."),
+    GET_SHOP_DETAIL_SUCCESS(HttpStatus.OK, "매장 상세 정보 반환이 완료되었습니다."),
 
     /**
      * 201 CREATED

--- a/src/main/java/org/sopt/tablingServer/common/exception/model/SuccessType.java
+++ b/src/main/java/org/sopt/tablingServer/common/exception/model/SuccessType.java
@@ -13,7 +13,8 @@ public enum SuccessType {
      * 200 OK
      */
     PROCESS_SUCCESS(HttpStatus.OK, "OK"),
-    GET_SHOP_LIST_BY_AVERAGE_WAITING_SUCCESS(HttpStatus.OK, "일 평균 대기인원을 기준으로 서울 남부 인기 매장 리스트 반환이 완료되었습니다.")
+    GET_SHOP_LIST_BY_AVERAGE_WAITING_SUCCESS(HttpStatus.OK, "일 평균 대기인원을 기준으로 서울 남부 인기 매장 리스트 반환이 완료되었습니다."),
+    GET_SHOP_DETAIL_SUCCESS(HttpStatus.OK, "매장 상세 정보 반완이 완료되었습니다."),
 
     /**
      * 201 CREATED

--- a/src/main/java/org/sopt/tablingServer/shop/ShopController.java
+++ b/src/main/java/org/sopt/tablingServer/shop/ShopController.java
@@ -2,13 +2,16 @@ package org.sopt.tablingServer.shop;
 
 import lombok.RequiredArgsConstructor;
 import org.sopt.tablingServer.common.dto.ApiResponse;
+import org.sopt.tablingServer.shop.dto.response.ShopDetailResponse;
 import org.sopt.tablingServer.shop.dto.response.ShopResponse;
 import org.springframework.web.bind.annotation.GetMapping;
+import org.springframework.web.bind.annotation.PathVariable;
 import org.springframework.web.bind.annotation.RequestMapping;
 import org.springframework.web.bind.annotation.RestController;
 
 import java.util.List;
 
+import static org.sopt.tablingServer.common.exception.model.SuccessType.GET_SHOP_DETAIL_SUCCESS;
 import static org.sopt.tablingServer.common.exception.model.SuccessType.GET_SHOP_LIST_BY_AVERAGE_WAITING_SUCCESS;
 
 @RestController
@@ -21,5 +24,10 @@ public class ShopController {
     @GetMapping
     public ApiResponse<List<ShopResponse>> getShopList() {
         return ApiResponse.success(GET_SHOP_LIST_BY_AVERAGE_WAITING_SUCCESS, shopService.getShopListByAverageWaiting());
+    }
+
+    @GetMapping("/{shopId}")
+    public ApiResponse<ShopDetailResponse> getShopDetail(@PathVariable Long shopId) {
+        return ApiResponse.success(GET_SHOP_DETAIL_SUCCESS, shopService.getShopDetailInfo(shopId));
     }
 }

--- a/src/main/java/org/sopt/tablingServer/shop/ShopService.java
+++ b/src/main/java/org/sopt/tablingServer/shop/ShopService.java
@@ -1,6 +1,7 @@
 package org.sopt.tablingServer.shop;
 
 import lombok.RequiredArgsConstructor;
+import org.sopt.tablingServer.shop.dto.response.ShopDetailResponse;
 import org.sopt.tablingServer.shop.dto.response.ShopResponse;
 import org.sopt.tablingServer.shop.infrastructure.ShopJpaRepository;
 import org.springframework.stereotype.Service;
@@ -22,5 +23,10 @@ public class ShopService {
         return shopJpaRepository.findAllByOrderByAverageWaitingDesc().stream()
                 .map(ShopResponse::of)
                 .collect(Collectors.toList());
+    }
+
+    public ShopDetailResponse getShopDetailInfo(Long shopId) {
+
+        return ShopDetailResponse.of(shopJpaRepository.findByIdOrThrow(shopId));
     }
 }

--- a/src/main/java/org/sopt/tablingServer/shop/domain/Menu.java
+++ b/src/main/java/org/sopt/tablingServer/shop/domain/Menu.java
@@ -23,6 +23,8 @@ public class Menu extends BaseTimeEntity {
     //    @ColumnDefault("https://github.com/DOSOPT-CDS-TABLING/Tabling-Server/assets/67463603/378964af-b46a-45c2-87ed-31d8a78fa002.png")
     private String menuPhotoUrl;
 
+    private String menuName;
+
     @Column(nullable = false)
     private Integer price;
 }

--- a/src/main/java/org/sopt/tablingServer/shop/domain/Menu.java
+++ b/src/main/java/org/sopt/tablingServer/shop/domain/Menu.java
@@ -21,8 +21,10 @@ public class Menu extends BaseTimeEntity {
     private String menuCategory;
 
     //    @ColumnDefault("https://github.com/DOSOPT-CDS-TABLING/Tabling-Server/assets/67463603/378964af-b46a-45c2-87ed-31d8a78fa002.png")
+    @Column(nullable = false)
     private String menuPhotoUrl;
 
+    @Column(nullable = false)
     private String menuName;
 
     @Column(nullable = false)

--- a/src/main/java/org/sopt/tablingServer/shop/domain/Review.java
+++ b/src/main/java/org/sopt/tablingServer/shop/domain/Review.java
@@ -23,5 +23,5 @@ public class Review extends BaseTimeEntity {
 
     private int dayBefore;
 
-    private String content;
+    private String reviewContent;
 }

--- a/src/main/java/org/sopt/tablingServer/shop/dto/response/MenuInfoResponse.java
+++ b/src/main/java/org/sopt/tablingServer/shop/dto/response/MenuInfoResponse.java
@@ -1,0 +1,22 @@
+package org.sopt.tablingServer.shop.dto.response;
+
+import com.fasterxml.jackson.databind.PropertyNamingStrategies;
+import com.fasterxml.jackson.databind.annotation.JsonNaming;
+import org.sopt.tablingServer.shop.domain.Menu;
+
+@JsonNaming(PropertyNamingStrategies.SnakeCaseStrategy.class)
+public record MenuInfoResponse(
+        Long menuId,
+        String menuPhotoUrl,
+        String menuName,
+        int price
+) {
+    public static MenuInfoResponse of(Menu menu) {
+        return new MenuInfoResponse(
+                menu.getId(),
+                menu.getMenuPhotoUrl(),
+                menu.getMenuName(),
+                menu.getPrice()
+        );
+    }
+}

--- a/src/main/java/org/sopt/tablingServer/shop/dto/response/MenuResponse.java
+++ b/src/main/java/org/sopt/tablingServer/shop/dto/response/MenuResponse.java
@@ -15,7 +15,7 @@ public record MenuResponse(
 ) {
     // 메뉴의 카테고리에 따라 그룹핑 하여 반환
     public static List<MenuResponse> of(List<Menu> menuList) {
-        Map<String, List<MenuInfoResponse>> groupedMenus = menuList.stream()
+        Map<String, List<MenuInfoResponse>> groupedMenuList = menuList.stream()
                 .collect(Collectors.groupingBy(
                         Menu::getMenuCategory,
                         Collectors.mapping(
@@ -24,7 +24,7 @@ public record MenuResponse(
                         )
                 ));
 
-        return groupedMenus.entrySet().stream()
+        return groupedMenuList.entrySet().stream()
                 .sorted(Map.Entry.comparingByKey())
                 .map(entry -> new MenuResponse(entry.getKey(), entry.getValue()))
                 .collect(Collectors.toList());

--- a/src/main/java/org/sopt/tablingServer/shop/dto/response/MenuResponse.java
+++ b/src/main/java/org/sopt/tablingServer/shop/dto/response/MenuResponse.java
@@ -24,6 +24,7 @@ public record MenuResponse(
                 ));
 
         return groupedMenus.entrySet().stream()
+                .sorted(Map.Entry.comparingByKey())
                 .map(entry -> new MenuResponse(entry.getKey(), entry.getValue()))
                 .collect(Collectors.toList());
     }

--- a/src/main/java/org/sopt/tablingServer/shop/dto/response/MenuResponse.java
+++ b/src/main/java/org/sopt/tablingServer/shop/dto/response/MenuResponse.java
@@ -13,6 +13,7 @@ public record MenuResponse(
         String menuCategory,
         List<MenuInfoResponse> menuInfoList
 ) {
+    // 메뉴의 카테고리에 따라 그룹핑 하여 반환
     public static List<MenuResponse> of(List<Menu> menuList) {
         Map<String, List<MenuInfoResponse>> groupedMenus = menuList.stream()
                 .collect(Collectors.groupingBy(

--- a/src/main/java/org/sopt/tablingServer/shop/dto/response/MenuResponse.java
+++ b/src/main/java/org/sopt/tablingServer/shop/dto/response/MenuResponse.java
@@ -1,0 +1,30 @@
+package org.sopt.tablingServer.shop.dto.response;
+
+import com.fasterxml.jackson.databind.PropertyNamingStrategies;
+import com.fasterxml.jackson.databind.annotation.JsonNaming;
+import org.sopt.tablingServer.shop.domain.Menu;
+
+import java.util.List;
+import java.util.Map;
+import java.util.stream.Collectors;
+
+@JsonNaming(PropertyNamingStrategies.SnakeCaseStrategy.class)
+public record MenuResponse(
+        String menuCategory,
+        List<MenuInfoResponse> menuInfoList
+) {
+    public static List<MenuResponse> of(List<Menu> menuList) {
+        Map<String, List<MenuInfoResponse>> groupedMenus = menuList.stream()
+                .collect(Collectors.groupingBy(
+                        Menu::getMenuCategory,
+                        Collectors.mapping(
+                                MenuInfoResponse::of,
+                                Collectors.toList()
+                        )
+                ));
+
+        return groupedMenus.entrySet().stream()
+                .map(entry -> new MenuResponse(entry.getKey(), entry.getValue()))
+                .collect(Collectors.toList());
+    }
+}

--- a/src/main/java/org/sopt/tablingServer/shop/dto/response/ReviewResponse.java
+++ b/src/main/java/org/sopt/tablingServer/shop/dto/response/ReviewResponse.java
@@ -1,0 +1,24 @@
+package org.sopt.tablingServer.shop.dto.response;
+
+import com.fasterxml.jackson.databind.PropertyNamingStrategies;
+import com.fasterxml.jackson.databind.annotation.JsonNaming;
+import org.sopt.tablingServer.shop.domain.Review;
+
+@JsonNaming(PropertyNamingStrategies.SnakeCaseStrategy.class)
+public record ReviewResponse(
+        Long reviewId,
+        float star,
+        String reviewerName,
+        int dayBefore,
+        String reviewContent
+) {
+    public static ReviewResponse of(Review review) {
+        return new ReviewResponse(
+                review.getId(),
+                review.getStar(),
+                review.getReviewerName(),
+                review.getDayBefore(),
+                review.getReviewContent()
+        );
+    }
+}

--- a/src/main/java/org/sopt/tablingServer/shop/dto/response/ShopDetailResponse.java
+++ b/src/main/java/org/sopt/tablingServer/shop/dto/response/ShopDetailResponse.java
@@ -1,0 +1,69 @@
+package org.sopt.tablingServer.shop.dto.response;
+
+import com.fasterxml.jackson.databind.PropertyNamingStrategies;
+import com.fasterxml.jackson.databind.annotation.JsonNaming;
+import org.sopt.tablingServer.shop.domain.Review;
+import org.sopt.tablingServer.shop.domain.Shop;
+
+import java.util.List;
+import java.util.stream.Collectors;
+
+@JsonNaming(PropertyNamingStrategies.SnakeCaseStrategy.class)
+public record ShopDetailResponse(
+        // 기본 정보
+        Long shopId,
+        List<String> detailPhotoList,
+        String name,
+        String longAddress,
+
+        // 영업 정보
+        String salesTime,
+        String waitingTime,
+        String restTime,
+        String restDay,
+        String phoneNumber,
+
+        // 해시 태그 (매장 PICK!), 매장 소개
+        List<String> hashTagList,
+        String introduceContent,
+
+        // 전체 메뉴
+        List<MenuResponse> menuList,
+
+        // 리뷰 정보
+        float averageStar,
+        int reviewCount,
+        List<Float> detailStarList,
+        List<ReviewResponse> reviewList
+) {
+    public static ShopDetailResponse of(Shop shop) {
+        return new ShopDetailResponse(
+                shop.getId(),
+                shop.getDetailPhotoList(),
+                shop.getName(),
+                shop.getLongAddress(),
+
+                shop.getSalesInfo().getSalesTime(),
+                shop.getSalesInfo().getWaitingTime(),
+                shop.getSalesInfo().getRestTime(),
+                shop.getSalesInfo().getRestDay(),
+                shop.getSalesInfo().getPhoneNumber(),
+
+                shop.getHashTagList(),
+                shop.getIntroduceContent(),
+
+                MenuResponse.of(shop.getMenuList()),
+
+                shop.getAverageStar(),
+                shop.getReviewCount(),
+                shop.getDetailStarList(),
+                convertReviewsToResponses(shop.getReviewList())
+        );
+    }
+
+    private static List<ReviewResponse> convertReviewsToResponses(List<Review> reviewList) {
+        return reviewList.stream()
+                .map(ReviewResponse::of)
+                .collect(Collectors.toList());
+    }
+}

--- a/src/main/java/org/sopt/tablingServer/shop/infrastructure/ShopJpaRepository.java
+++ b/src/main/java/org/sopt/tablingServer/shop/infrastructure/ShopJpaRepository.java
@@ -1,5 +1,7 @@
 package org.sopt.tablingServer.shop.infrastructure;
 
+import org.sopt.tablingServer.common.exception.model.BusinessException;
+import org.sopt.tablingServer.common.exception.model.ErrorType;
 import org.sopt.tablingServer.shop.domain.Shop;
 import org.springframework.data.jpa.repository.JpaRepository;
 
@@ -7,4 +9,9 @@ import java.util.List;
 
 public interface ShopJpaRepository extends JpaRepository<Shop, Long> {
     List<Shop> findAllByOrderByAverageWaitingDesc();
+
+    default Shop findByIdOrThrow(Long id) {
+        return findById(id).orElseThrow(
+                () -> new BusinessException(ErrorType.NOT_FOUND_SHOP_ERROR));
+    }
 }


### PR DESCRIPTION
## 📌 관련 이슈
closed #3

## ✨ 어떤 이유로 변경된 내용인지
- 매장 상세 뷰에 들어갈 많은 양의 정보를 한번에 반환해주는 API를 개발했습니다.

- shop_id가 잘못 입력되었을 때 예외처리를 하였습니다.

- 엔티티의 헷갈리는 필드 명을 일부 수정하였습니다.

- 메뉴의 카테고리에 따라 그룹핑하는 부분 코드가 조금 어려워서 공유드립니다! (chatGPT의 도움을 받았습니다..)
  <img width="500" alt="image" src="https://github.com/DOSOPT-CDS-TABLING/Tabling-Server/assets/67463603/739f923d-a0de-4728-befe-a0446ce81ac8">


## 🙏 검토 혹은 리뷰어에게 남기고 싶은 말
- 포스트맨 테스트 결과입니다

  <img width="800" alt="image" src="https://github.com/DOSOPT-CDS-TABLING/Tabling-Server/assets/67463603/9c230a13-82f1-4e8a-891b-367c27f59937">
  <img width="800" alt="image" src="https://github.com/DOSOPT-CDS-TABLING/Tabling-Server/assets/67463603/3612c537-6662-4537-86ec-c0940f3520dd">

- 잘못된 shop_id를 주었을 경우
 
  <img width="800" alt="image" src="https://github.com/DOSOPT-CDS-TABLING/Tabling-Server/assets/67463603/d397989e-f51c-4b30-bb9a-c85006cd2be5">


