### PR TITLE
chore: 배포를 위한 추가 설정

### DIFF
--- a/src/main/java/org/sopt/tablingServer/common/constant/Constraint.java
+++ b/src/main/java/org/sopt/tablingServer/common/constant/Constraint.java
@@ -9,4 +9,7 @@ public class Constraint {
     public static final int MAX_PERSON_COUNT = 99;
     public static final int MAX_BEFORE_COUNT = 20;
     public static final int MAX_PRICE_STEP = 20;
+
+    public static final int REVIEW_DEADLINE_DAYS = 4;
+    public static final int MINUTES_IN_A_DAY = 1440;
 }

--- a/src/main/java/org/sopt/tablingServer/order/controller/OrderController.java
+++ b/src/main/java/org/sopt/tablingServer/order/controller/OrderController.java
@@ -13,7 +13,6 @@ import org.sopt.tablingServer.order.dto.request.OrderCompleteRequest;
 import org.sopt.tablingServer.order.service.OrderService;
 
 import java.util.List;
-import java.util.stream.Collectors;
 
 import lombok.RequiredArgsConstructor;
 
@@ -27,6 +26,7 @@ import org.springframework.web.bind.annotation.RestController;
 import static org.sopt.tablingServer.common.exception.model.SuccessType.GET_ORDER_DETAIL_SUCCESS;
 import static org.sopt.tablingServer.common.exception.model.SuccessType.GET_ORDER_LIST_SUCCESS;
 import static org.sopt.tablingServer.common.exception.model.SuccessType.UPDATE_ORDER_STATUS_COMPLETE_SUCCESS;
+
 import org.springframework.web.bind.annotation.*;
 
 import static org.sopt.tablingServer.common.exception.model.SuccessType.*;
@@ -40,32 +40,21 @@ public class OrderController {
 
     @GetMapping
     public ApiResponse<List<OrderListResponse>> orderList() {
-        List<OrderListResponse> responses = orderService.findOrderList()
-                .stream()
-                .map(OrderListResponse::of)
-                .collect(Collectors.toList());
-
-        return ApiResponse.success(GET_ORDER_LIST_SUCCESS, responses);
+        return ApiResponse.success(GET_ORDER_LIST_SUCCESS, orderService.findOrderList());
     }
 
     @GetMapping("/{orderId}")
     public ApiResponse<OrderDetailResponse> orderDetail(@PathVariable Long orderId) {
-        OrderDetailResponse response = OrderDetailResponse.of(orderService.findOrder(orderId));
-
-        return ApiResponse.success(GET_ORDER_DETAIL_SUCCESS, response);
+        return ApiResponse.success(GET_ORDER_DETAIL_SUCCESS, orderService.findOrder(orderId));
     }
 
     @PatchMapping("/complete")
     public ApiResponse<OrderCompleteResponse> completeOrderStatus(@RequestBody OrderCompleteRequest request) {
-        OrderCompleteResponse response = OrderCompleteResponse.of(orderService.updateOrderStatusComplete(request.orderId()));
-
-        return ApiResponse.success(UPDATE_ORDER_STATUS_COMPLETE_SUCCESS, response);
+        return ApiResponse.success(UPDATE_ORDER_STATUS_COMPLETE_SUCCESS, orderService.updateOrderStatusComplete(request.orderId()));
     }
 
     @PostMapping("/reserve")
     public ApiResponse<OrderReserveResponse> orderReserve(@RequestBody @Valid OrderReserveRequest request) {
-        OrderReserveResponse response = OrderReserveResponse.of(orderService.createOrder(request.shopId(), request.personCount()));
-
-        return ApiResponse.success(RESERVE_ORDER_SUCCESS, response);
+        return ApiResponse.success(RESERVE_ORDER_SUCCESS, orderService.createOrder(request.shopId(), request.personCount()));
     }
 }

--- a/src/main/java/org/sopt/tablingServer/order/dto/response/OrderCompleteResponse.java
+++ b/src/main/java/org/sopt/tablingServer/order/dto/response/OrderCompleteResponse.java
@@ -1,7 +1,6 @@
 package org.sopt.tablingServer.order.dto.response;
 
 import com.fasterxml.jackson.databind.PropertyNamingStrategies;
-import com.fasterxml.jackson.databind.PropertyNamingStrategy;
 import com.fasterxml.jackson.databind.annotation.JsonNaming;
 import org.sopt.tablingServer.order.domain.Order;
 

--- a/src/main/java/org/sopt/tablingServer/order/dto/response/OrderCompleteResponse.java
+++ b/src/main/java/org/sopt/tablingServer/order/dto/response/OrderCompleteResponse.java
@@ -1,10 +1,11 @@
 package org.sopt.tablingServer.order.dto.response;
 
+import com.fasterxml.jackson.databind.PropertyNamingStrategies;
 import com.fasterxml.jackson.databind.PropertyNamingStrategy;
 import com.fasterxml.jackson.databind.annotation.JsonNaming;
 import org.sopt.tablingServer.order.domain.Order;
 
-@JsonNaming(PropertyNamingStrategy.SnakeCaseStrategy.class)
+@JsonNaming(PropertyNamingStrategies.SnakeCaseStrategy.class)
 public record OrderCompleteResponse(
         Long orderId,
         int waitingNumber,

--- a/src/main/java/org/sopt/tablingServer/order/dto/response/OrderDetailResponse.java
+++ b/src/main/java/org/sopt/tablingServer/order/dto/response/OrderDetailResponse.java
@@ -3,7 +3,6 @@ package org.sopt.tablingServer.order.dto.response;
 import com.fasterxml.jackson.databind.PropertyNamingStrategies;
 import org.sopt.tablingServer.order.domain.Order;
 
-import com.fasterxml.jackson.databind.PropertyNamingStrategy;
 import com.fasterxml.jackson.databind.annotation.JsonNaming;
 
 import java.time.LocalDateTime;

--- a/src/main/java/org/sopt/tablingServer/order/dto/response/OrderDetailResponse.java
+++ b/src/main/java/org/sopt/tablingServer/order/dto/response/OrderDetailResponse.java
@@ -1,5 +1,6 @@
 package org.sopt.tablingServer.order.dto.response;
 
+import com.fasterxml.jackson.databind.PropertyNamingStrategies;
 import org.sopt.tablingServer.order.domain.Order;
 
 import com.fasterxml.jackson.databind.PropertyNamingStrategy;
@@ -9,7 +10,7 @@ import java.time.LocalDateTime;
 import java.time.format.DateTimeFormatter;
 import java.util.Locale;
 
-@JsonNaming(PropertyNamingStrategy.SnakeCaseStrategy.class)
+@JsonNaming(PropertyNamingStrategies.SnakeCaseStrategy.class)
 public record OrderDetailResponse(
         Long orderId,
         String shopName,

--- a/src/main/java/org/sopt/tablingServer/order/dto/response/OrderListResponse.java
+++ b/src/main/java/org/sopt/tablingServer/order/dto/response/OrderListResponse.java
@@ -1,12 +1,13 @@
 package org.sopt.tablingServer.order.dto.response;
 
+import com.fasterxml.jackson.databind.PropertyNamingStrategies;
 import com.fasterxml.jackson.databind.PropertyNamingStrategy;
 import com.fasterxml.jackson.databind.annotation.JsonNaming;
 import java.time.LocalDateTime;
 import java.time.temporal.ChronoUnit;
 import org.sopt.tablingServer.order.domain.Order;
 
-@JsonNaming(PropertyNamingStrategy.SnakeCaseStrategy.class)
+@JsonNaming(PropertyNamingStrategies.SnakeCaseStrategy.class)
 public record OrderListResponse(
         Long orderId,
         String orderStatus,

--- a/src/main/java/org/sopt/tablingServer/order/dto/response/OrderListResponse.java
+++ b/src/main/java/org/sopt/tablingServer/order/dto/response/OrderListResponse.java
@@ -1,17 +1,23 @@
 package org.sopt.tablingServer.order.dto.response;
 
 import com.fasterxml.jackson.databind.PropertyNamingStrategies;
-import com.fasterxml.jackson.databind.PropertyNamingStrategy;
 import com.fasterxml.jackson.databind.annotation.JsonNaming;
 import java.time.LocalDateTime;
+import java.time.format.DateTimeFormatter;
 import java.time.temporal.ChronoUnit;
+import java.util.Locale;
+
 import org.sopt.tablingServer.order.domain.Order;
+
+import static org.sopt.tablingServer.common.constant.Constraint.MINUTES_IN_A_DAY;
+import static org.sopt.tablingServer.common.constant.Constraint.REVIEW_DEADLINE_DAYS;
 
 @JsonNaming(PropertyNamingStrategies.SnakeCaseStrategy.class)
 public record OrderListResponse(
         Long orderId,
         String orderStatus,
         String shopName,
+        String orderDate,
         int personCount,
         int waitingNumber,
         int beforeCount,
@@ -23,6 +29,7 @@ public record OrderListResponse(
                 order.getId(),
                 order.getOrderStatus().getValue(),
                 order.getShopName(),
+                formatOrderDate(order.getOrderDate()),
                 order.getPersonCount(),
                 order.getWaitingNumber(),
                 order.getBeforeCount(),
@@ -31,8 +38,6 @@ public record OrderListResponse(
     }
 
     private static long getRemainingReviewPeriod(LocalDateTime orderDate) {
-        final int REVIEW_DEADLINE_DAYS = 4;
-        final int MINUTES_IN_A_DAY = 1440;
 
         long minutesDifference = ChronoUnit.MINUTES.between(LocalDateTime.now(),
                 orderDate.plusDays(REVIEW_DEADLINE_DAYS));
@@ -42,5 +47,11 @@ public record OrderListResponse(
         }
         // REVIEW_DEADLINE이 지나면 -1일이라고 표시하기 위함
         return minutesDifference / MINUTES_IN_A_DAY - 1;
+    }
+
+    private static String formatOrderDate(LocalDateTime orderDate) {
+        DateTimeFormatter formatter = DateTimeFormatter.ofPattern("MM월 dd일 (E)", Locale.KOREA);
+
+        return orderDate.format(formatter);
     }
 }

--- a/src/main/java/org/sopt/tablingServer/order/service/OrderService.java
+++ b/src/main/java/org/sopt/tablingServer/order/service/OrderService.java
@@ -62,6 +62,8 @@ public class OrderService {
         RandomResult result = getRandomResult();
 
         // 기왕 랜덤 생성한 김에 Shop에서도 수정
+        // 이부분은 실제로는 동시성 이슈가 발생할 수 있어서, 기존의 값에 더하는 식으로 업데이트 해주거나
+        // Shop에서 컬럼으로 관리 안하고 Order 테이블의 레코드를 활용해 계산하면 좋을 것임
         targetShop.changeCurrentWaiting(result.beforeCount() + 1);
 
         Order order = Order.builder()

--- a/src/main/java/org/sopt/tablingServer/order/service/OrderService.java
+++ b/src/main/java/org/sopt/tablingServer/order/service/OrderService.java
@@ -1,5 +1,6 @@
 package org.sopt.tablingServer.order.service;
 
+import org.sopt.tablingServer.order.domain.OrderStatus;
 import org.sopt.tablingServer.order.dto.response.OrderCompleteResponse;
 import org.sopt.tablingServer.order.dto.response.OrderDetailResponse;
 import org.sopt.tablingServer.order.dto.response.OrderListResponse;
@@ -15,6 +16,7 @@ import org.sopt.tablingServer.common.exception.model.BusinessException;
 import org.springframework.stereotype.Service;
 import org.springframework.transaction.annotation.Transactional;
 
+import java.util.Comparator;
 import java.util.List;
 import java.util.Random;
 import java.time.LocalDateTime;
@@ -22,9 +24,11 @@ import java.util.stream.Collectors;
 
 import lombok.RequiredArgsConstructor;
 
+import static java.util.Comparator.*;
 import static org.sopt.tablingServer.common.constant.Constraint.*;
 import static org.sopt.tablingServer.common.constant.DefaultString.DEFAULT_REQUEST_CONTENT;
 import static org.sopt.tablingServer.common.exception.model.ErrorType.TOO_MANY_PERSON_COUNT_ERROR;
+import static org.sopt.tablingServer.order.domain.OrderStatus.*;
 import static org.sopt.tablingServer.order.domain.OrderStatus.RESERVED;
 
 @Service
@@ -37,9 +41,10 @@ public class OrderService {
     public List<OrderListResponse> findOrderList() {
         return orderJpaRepository.findAll()
                 .stream()
+                .sorted(comparing(Order::getOrderStatus, comparing(status -> status == RESERVED ? 0 : 1)))
                 .map(OrderListResponse::of)
                 .collect(Collectors.toList());
-    }
+        }
 
     public OrderDetailResponse findOrder(Long orderId) {
         return OrderDetailResponse.of(orderJpaRepository.findByIdOrThrow(orderId));

--- a/src/main/java/org/sopt/tablingServer/shop/controller/ShopController.java
+++ b/src/main/java/org/sopt/tablingServer/shop/controller/ShopController.java
@@ -22,18 +22,11 @@ public class ShopController {
 
     @GetMapping
     public ApiResponse<List<ShopResponse>> shopList() {
-        List<ShopResponse> response = shopService.findShopListOrderByAverageWaiting()
-                .stream()
-                .map(ShopResponse::of)
-                .collect(Collectors.toList());
-
-        return ApiResponse.success(GET_SHOP_LIST_BY_AVERAGE_WAITING_SUCCESS, response);
+        return ApiResponse.success(GET_SHOP_LIST_BY_AVERAGE_WAITING_SUCCESS, shopService.findShopListOrderByAverageWaiting());
     }
 
     @GetMapping("/{shopId}")
     public ApiResponse<ShopDetailResponse> shopDetail(@PathVariable Long shopId) {
-        ShopDetailResponse response = ShopDetailResponse.of(shopService.findShopDetailInfo(shopId));
-
-        return ApiResponse.success(GET_SHOP_DETAIL_SUCCESS, response);
+        return ApiResponse.success(GET_SHOP_DETAIL_SUCCESS, shopService.findShopDetailInfo(shopId));
     }
 }

--- a/src/main/java/org/sopt/tablingServer/shop/service/ShopService.java
+++ b/src/main/java/org/sopt/tablingServer/shop/service/ShopService.java
@@ -1,12 +1,14 @@
 package org.sopt.tablingServer.shop.service;
 
 import lombok.RequiredArgsConstructor;
-import org.sopt.tablingServer.shop.domain.Shop;
+import org.sopt.tablingServer.shop.dto.response.shop.ShopDetailResponse;
+import org.sopt.tablingServer.shop.dto.response.shop.ShopResponse;
 import org.sopt.tablingServer.shop.infrastructure.ShopJpaRepository;
 import org.springframework.stereotype.Service;
 import org.springframework.transaction.annotation.Transactional;
 
 import java.util.List;
+import java.util.stream.Collectors;
 
 
 @Service
@@ -16,14 +18,14 @@ public class ShopService {
 
     private final ShopJpaRepository shopJpaRepository;
 
-
-    public List<Shop> findShopListOrderByAverageWaiting() {
-
-        return shopJpaRepository.findAllByOrderByAverageWaitingDesc();
+    public List<ShopResponse> findShopListOrderByAverageWaiting() {
+        return shopJpaRepository.findAllByOrderByAverageWaitingDesc()
+                .stream()
+                .map(ShopResponse::of)
+                .collect(Collectors.toList());
     }
 
-    public Shop findShopDetailInfo(Long shopId) {
-
-        return shopJpaRepository.findByIdOrThrow(shopId);
+    public ShopDetailResponse findShopDetailInfo(Long shopId) {
+        return ShopDetailResponse.of(shopJpaRepository.findByIdOrThrow(shopId));
     }
 }

--- a/src/main/resources/application.yml
+++ b/src/main/resources/application.yml
@@ -13,6 +13,4 @@ spring:
           auto_quote_keyword: true
 
   config:
-    import: application-secret.properties
-
-
+    import: optional:application-secret.properties


### PR DESCRIPTION
## 📌 관련 이슈
closed #16 
closed #13

## ✨ 어떤 이유로 변경된 내용인지
- Service 단에서 dto에 의존하도록 다시 변경하였습니다. (영속성을 반환하는 엔티티를 함부러 반환하는 것은 위험할 수 있기 때문)

- 배포를 위한 yml 파일을 수정하였습니다.

- 주문 내역 리스트를 출력하는 기능에서 이용 예정인 주문 내역부터 출력하도록 수정했습니다.
  <img width="500" alt="image" src="https://github.com/DOSOPT-CDS-TABLING/Tabling-Server/assets/67463603/82de55dd-86f3-4cce-8ab4-dd7e74f72c5e">

- 원격 줄서기 내역 반환에서 예약 날짜 필드가 빠진 것 해결
  아래와 같이 order_date를 필요한 형식에 맞추어 출력하도록 변경했습니다.
  <img width="200" alt="image" src="https://github.com/DOSOPT-CDS-TABLING/Tabling-Server/assets/67463603/db650209-179d-475b-9401-cebdec2ddc13">


## 🙏 검토 혹은 리뷰어에게 남기고 싶은 말
- 화이팅!